### PR TITLE
ci(renovate): improve merge speed + auto merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,16 +2,23 @@
   "extends": ["config:base", "group:allNonMajor"],
   "labels": ["type: dependencies"],
   "vulnerabilityAlerts": {
-    "labels": ["type: security"]
+    "labels": ["type: dependencies", "type: security"],
+    "automerge": true,
+    "platformAutomerge": true
   },
   "rollbackPrs": true,
   "reviewersFromCodeOwners": true,
   "prHourlyLimit": 10,
-  "lockFileMaintenance": { "enabled": true },
+  "lockFileMaintenance": { 
+    "enabled": true, 
+    "automerge": true,
+    "platformAutomerge": true
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
platformAutomerge Allows Renovate to use GitHubs built in auto merge functionality. This speeds up the time it takes from test pass to run to merged for master 
Make sure it is enabled in the repo settings, it’s located under “Pull Requests” then enable Allow auto-merge 

also enabled auto merge for vulnerabilityAlerts and lockFileMaintenance