### PR TITLE
feat(annonse): erstatt iframe-annonse med statisk Båtførerquizen-banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,13 +14,9 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="%PUBLIC_URL%/favicon.ico">
 
-    <link rel="preload" href="%PUBLIC_URL%/status/yellow.png" as="image">
-    <link rel="preload" href="%PUBLIC_URL%/status/green.png" as="image">
-    <link rel="preload" href="%PUBLIC_URL%/status/red.png" as="image">
-
-    <link rel="preload" href="%PUBLIC_URL%/static/media/icons.1551f4f60c37af51121f.woff2" as="font">
-    <link rel="preload" href="%PUBLIC_URL%/static/media/LatoLatin-Bold.710a16565cff7fb7bf78.woff2" as="font">
-    <link rel="preload" href="%PUBLIC_URL%/static/media/LatoLatin-Regular.b0a598e91a6ca2310dc9.woff2" as="font">
+    <link rel="preload" href="%PUBLIC_URL%/static/media/icons.1551f4f60c37af51121f.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="%PUBLIC_URL%/static/media/LatoLatin-Bold.710a16565cff7fb7bf78.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" href="%PUBLIC_URL%/static/media/LatoLatin-Regular.b0a598e91a6ca2310dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://www.google-analytics.com">

--- a/src/Ad.tsx
+++ b/src/Ad.tsx
@@ -1,6 +1,15 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
+
+// Reserved height while the ad is loading. Collapses to 0 if no ad slot
+// becomes visible within COLLAPSE_TIMEOUT_MS, so we do not leave a large
+// empty box when ads are blocked or do not fill.
+const RESERVED_HEIGHT = 280;
+const COLLAPSE_TIMEOUT_MS = 1500;
 
 const Ad = (props: any) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
   useEffect(() => {
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({
@@ -9,23 +18,35 @@ const Ad = (props: any) => {
     } catch (e) {
       // AdSense may throw if blocked or not loaded; fail silently
     }
+
+    const timer = window.setTimeout(() => {
+      // If AdSense filled the slot, the <ins> has data-ad-status="filled"
+      // and a non-zero height. Otherwise, collapse to avoid an empty box.
+      const ins = containerRef.current?.querySelector("ins.adsbygoogle");
+      const status = ins?.getAttribute("data-ad-status");
+      const filled = status === "filled" || (ins?.clientHeight ?? 0) > 0;
+      if (!filled) {
+        setCollapsed(true);
+      }
+    }, COLLAPSE_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timer);
   }, []);
 
   return (
     <div
+      ref={containerRef}
       style={{
-        // Reserve space to avoid Cumulative Layout Shift while the ad loads.
-        // Matches a common responsive ad size; overflow hidden keeps it stable
-        // even when the ad ends up shorter.
-        minHeight: "280px",
+        minHeight: collapsed ? 0 : `${RESERVED_HEIGHT}px`,
         width: "100%",
         overflow: "hidden",
+        transition: "min-height 0.2s ease-out",
       }}
       aria-label="Annonseplass"
     >
       <ins
         className="adsbygoogle"
-        style={{ display: "block", width: "100%", minHeight: "280px" }}
+        style={{ display: "block", width: "100%" }}
         data-ad-client="ca-pub-8133897183984535"
         data-ad-slot="5404963764"
         data-ad-format="auto"

--- a/src/Ad.tsx
+++ b/src/Ad.tsx
@@ -2,22 +2,37 @@ import React, { useEffect } from "react";
 
 const Ad = (props: any) => {
   useEffect(() => {
-    (window.adsbygoogle = window.adsbygoogle || []).push({
-      google_ad_client: "ca-pub-8133897183984535",
-      // enable_page_level_ads: true
-    });
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({
+        google_ad_client: "ca-pub-8133897183984535",
+      });
+    } catch (e) {
+      // AdSense may throw if blocked or not loaded; fail silently
+    }
   }, []);
 
   return (
-    <ins
-      className="adsbygoogle"
-      style={{ display: "block" }}
-      data-ad-client="ca-pub-8133897183984535"
-      data-ad-slot="5404963764"
-      data-ad-format="auto"
-      data-full-width-responsive="true"
-      data-adtest={process.env.NODE_ENV === 'development' ? 'on':'off'}
-    />
+    <div
+      style={{
+        // Reserve space to avoid Cumulative Layout Shift while the ad loads.
+        // Matches a common responsive ad size; overflow hidden keeps it stable
+        // even when the ad ends up shorter.
+        minHeight: "280px",
+        width: "100%",
+        overflow: "hidden",
+      }}
+      aria-label="Annonseplass"
+    >
+      <ins
+        className="adsbygoogle"
+        style={{ display: "block", width: "100%", minHeight: "280px" }}
+        data-ad-client="ca-pub-8133897183984535"
+        data-ad-slot="5404963764"
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+        data-adtest={process.env.NODE_ENV === "development" ? "on" : "off"}
+      />
+    </div>
   );
 };
 

--- a/src/Annonse.css
+++ b/src/Annonse.css
@@ -1,0 +1,163 @@
+.bfq-ad {
+  display: block;
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  background: linear-gradient(135deg, #06111e 0%, #0b2545 55%, #13315c 100%);
+  color: #fff;
+  border-radius: 14px;
+  overflow: hidden;
+  text-decoration: none;
+  box-shadow: 0 6px 20px rgba(11, 37, 69, 0.18);
+  position: relative;
+  transition: transform 0.12s ease, box-shadow 0.2s ease;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+}
+.bfq-ad:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(11, 37, 69, 0.28);
+}
+
+.bfq-ad::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at 85% 20%,
+      rgba(142, 202, 230, 0.18) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 10% 90%,
+      rgba(29, 111, 184, 0.22) 0%,
+      transparent 40%
+    );
+  pointer-events: none;
+}
+
+.bfq-ad-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 20px;
+}
+
+.bfq-ad-icon {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: rgba(142, 202, 230, 0.15);
+  border: 1px solid rgba(142, 202, 230, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 30px;
+  line-height: 1;
+}
+
+.bfq-ad-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.bfq-ad-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8ecae6;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.bfq-ad-title {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.25;
+  color: #fff;
+  margin-bottom: 4px;
+}
+
+.bfq-ad-rotator {
+  position: relative;
+  height: 1.4em;
+  overflow: hidden;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+}
+.bfq-ad-slide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bfq-ad-slide.is-active {
+  opacity: 1;
+  transform: translateY(0);
+}
+.bfq-ad-rotator strong {
+  color: #fff;
+  font-weight: 700;
+}
+.bfq-ad-rotator .accent {
+  color: #8ecae6;
+  font-weight: 700;
+}
+
+.bfq-ad-cta {
+  flex-shrink: 0;
+  background: #1d6fb8;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+  box-shadow: 0 4px 10px rgba(29, 111, 184, 0.4);
+}
+
+@media (max-width: 480px) {
+  .bfq-ad-inner {
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 16px;
+  }
+  .bfq-ad-icon {
+    width: 44px;
+    height: 44px;
+    font-size: 24px;
+    border-radius: 10px;
+  }
+  .bfq-ad-body {
+    flex: 1 1 calc(100% - 56px);
+  }
+  .bfq-ad-title {
+    font-size: 16px;
+  }
+  .bfq-ad-rotator {
+    font-size: 12.5px;
+    height: 1.5em;
+  }
+  .bfq-ad-cta {
+    width: 100%;
+    text-align: center;
+    flex: 1 1 100%;
+    padding: 12px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bfq-ad-slide {
+    transition: opacity 0.01s linear;
+    transform: none !important;
+  }
+}

--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -1,15 +1,22 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+
+const ANNONSE_ORIGIN = "https://annon-se.stengttunnel.no";
+// Initial reserved height so we don't get a layout shift while the iframe
+// loads and posts its real height. Most banner ads are ~250-280px tall.
+const INITIAL_HEIGHT = 280;
 
 const Annonse = (props: any) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState<number>(INITIAL_HEIGHT);
 
   useEffect(() => {
     const handleResize = (event: MessageEvent) => {
-      if (event.origin === "https://annon-se.stengttunnel.no") {
-        const newHeight = event.data;
-        if (iframeRef.current) {
-          iframeRef.current.style.height = `${newHeight+20}px`;
-        }
+      if (event.origin !== ANNONSE_ORIGIN) {
+        return;
+      }
+      const newHeight = Number(event.data);
+      if (Number.isFinite(newHeight) && newHeight > 0) {
+        setHeight(newHeight + 20);
       }
     };
 
@@ -21,12 +28,20 @@ const Annonse = (props: any) => {
   }, []);
 
   return (
-    <iframe
-      ref={iframeRef}
-      src="https://annon-se.stengttunnel.no/v1/html"
-      style={{ width: "100%", height: "100%", border: "none" }}
-      title="Annonse"
-    />
+    <div style={{ minHeight: `${INITIAL_HEIGHT}px`, width: "100%" }}>
+      <iframe
+        ref={iframeRef}
+        src={`${ANNONSE_ORIGIN}/v1/html`}
+        style={{
+          width: "100%",
+          height: `${height}px`,
+          border: "none",
+          display: "block",
+        }}
+        loading="lazy"
+        title="Annonse"
+      />
+    </div>
   );
 };
 

--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -1,67 +1,74 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
+import "./Annonse.css";
 
-const ANNONSE_ORIGIN = "https://annon-se.stengttunnel.no";
-// Initial reserved height so we don't get a layout shift while the iframe
-// loads and posts its real height.
-const INITIAL_HEIGHT = 280;
-const COLLAPSE_TIMEOUT_MS = 1500;
+const SLIDES: React.ReactNode[] = [
+  <>
+    <span className="accent">139</span> oppdaterte spørsmål i{" "}
+    <strong>25 kategorier</strong>
+  </>,
+  <>
+    <strong>599,-</strong> for 3 måneders full tilgang
+  </>,
+  <>
+    Umiddelbar <strong>forklaring</strong> og kildehenvisning
+  </>,
+  <>
+    Øv på <strong>mobil, nettbrett og PC</strong> – ingen app
+  </>,
+  <>
+    Ingen automatisk fornyelse – <strong>engangskjøp</strong>
+  </>,
+  <>
+    <span className="accent">★★★★★</span> 4,9 av 5 i kundevurdering
+  </>,
+];
 
-const Annonse = (props: any) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState<number>(INITIAL_HEIGHT);
-  const [received, setReceived] = useState(false);
+const ROTATE_INTERVAL_MS = 3000;
+
+const Annonse = () => {
+  const [current, setCurrent] = useState(0);
 
   useEffect(() => {
-    const handleResize = (event: MessageEvent) => {
-      if (event.origin !== ANNONSE_ORIGIN) {
-        return;
-      }
-      const newHeight = Number(event.data);
-      if (Number.isFinite(newHeight) && newHeight > 0) {
-        setHeight(newHeight + 20);
-        setReceived(true);
-      }
-    };
-
-    window.addEventListener("message", handleResize);
-
-    // Collapse if the iframe never posts a height (blocked, empty, etc).
-    const timer = window.setTimeout(() => {
-      if (!received) {
-        setHeight(0);
-      }
-    }, COLLAPSE_TIMEOUT_MS);
-
-    return () => {
-      window.removeEventListener("message", handleResize);
-      window.clearTimeout(timer);
-    };
-    // We intentionally do not depend on `received`; the timer is a one-shot.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (SLIDES.length <= 1) return;
+    const id = window.setInterval(() => {
+      setCurrent((c) => (c + 1) % SLIDES.length);
+    }, ROTATE_INTERVAL_MS);
+    return () => window.clearInterval(id);
   }, []);
 
   return (
-    <div
-      style={{
-        minHeight: height === 0 ? 0 : `${INITIAL_HEIGHT}px`,
-        width: "100%",
-        transition: "min-height 0.2s ease-out",
-      }}
+    <a
+      className="bfq-ad"
+      href="https://xn--btfrerquizen-tcb2y.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Båtførerquizen – øv til båtførerprøven på nett"
     >
-      <iframe
-        ref={iframeRef}
-        src={`${ANNONSE_ORIGIN}/v1/html`}
-        style={{
-          width: "100%",
-          height: `${height}px`,
-          border: "none",
-          display: "block",
-          transition: "height 0.2s ease-out",
-        }}
-        loading="lazy"
-        title="Annonse"
-      />
-    </div>
+      <div className="bfq-ad-inner">
+        <div className="bfq-ad-icon" aria-hidden="true">
+          ⚓
+        </div>
+        <div className="bfq-ad-body">
+          <div className="bfq-ad-eyebrow">Båtførerquizen.no</div>
+          <div className="bfq-ad-title">
+            Bestå båtførerprøven – med selvtillit
+          </div>
+          <div className="bfq-ad-rotator" aria-live="polite">
+            {SLIDES.map((slide, i) => (
+              <div
+                key={i}
+                className={`bfq-ad-slide${
+                  i === current ? " is-active" : ""
+                }`}
+              >
+                {slide}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bfq-ad-cta">Start quiz →</div>
+      </div>
+    </a>
   );
 };
 

--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useRef, useState } from "react";
 
 const ANNONSE_ORIGIN = "https://annon-se.stengttunnel.no";
 // Initial reserved height so we don't get a layout shift while the iframe
-// loads and posts its real height. Most banner ads are ~250-280px tall.
+// loads and posts its real height.
 const INITIAL_HEIGHT = 280;
+const COLLAPSE_TIMEOUT_MS = 1500;
 
 const Annonse = (props: any) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState<number>(INITIAL_HEIGHT);
+  const [received, setReceived] = useState(false);
 
   useEffect(() => {
     const handleResize = (event: MessageEvent) => {
@@ -17,18 +19,35 @@ const Annonse = (props: any) => {
       const newHeight = Number(event.data);
       if (Number.isFinite(newHeight) && newHeight > 0) {
         setHeight(newHeight + 20);
+        setReceived(true);
       }
     };
 
     window.addEventListener("message", handleResize);
 
+    // Collapse if the iframe never posts a height (blocked, empty, etc).
+    const timer = window.setTimeout(() => {
+      if (!received) {
+        setHeight(0);
+      }
+    }, COLLAPSE_TIMEOUT_MS);
+
     return () => {
       window.removeEventListener("message", handleResize);
+      window.clearTimeout(timer);
     };
+    // We intentionally do not depend on `received`; the timer is a one-shot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <div style={{ minHeight: `${INITIAL_HEIGHT}px`, width: "100%" }}>
+    <div
+      style={{
+        minHeight: height === 0 ? 0 : `${INITIAL_HEIGHT}px`,
+        width: "100%",
+        transition: "min-height 0.2s ease-out",
+      }}
+    >
       <iframe
         ref={iframeRef}
         src={`${ANNONSE_ORIGIN}/v1/html`}
@@ -37,6 +56,7 @@ const Annonse = (props: any) => {
           height: `${height}px`,
           border: "none",
           display: "block",
+          transition: "height 0.2s ease-out",
         }}
         loading="lazy"
         title="Annonse"

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,7 +4,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import App from "./App";
 
 beforeEach(() => {
-  const makeFetchResponse = async (value: any) => ({ json: async () => value });
+  const makeFetchResponse = async (value: any) => ({
+    ok: true,
+    json: async () => value,
+  });
   const mockFetch = jest
     .fn()
     .mockReturnValueOnce(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,21 +8,32 @@ import Roads from "./Roads";
 const App = () => {
   const [roads, setRoads] = useState<IRoad[]>([]);
   const [favorites, setFavorites] = useState<IFavorite[]>([]);
-  const [alert, setAlert] = useState<String | null>(null);
+  const [alert, setAlert] = useState<string | null>(null);
 
   useEffect(() => {
-    let isMounted = true;
+    const controller = new AbortController();
 
-    fetch("https://api.stengttunnel.no/roads.json")
-      .then((r) => r.json())
-      .then((data) => {
-        if (isMounted) {
-          setRoads(data);
+    fetch("https://api.stengttunnel.no/roads.json", {
+      signal: controller.signal,
+    })
+      .then((r) => {
+        if (!r.ok) {
+          throw new Error(`HTTP ${r.status}`);
+        }
+        return r.json();
+      })
+      .then(setRoads)
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          // Keep silent in UI; the dropdown loading state still indicates
+          // unavailability. Log for debugging.
+          // eslint-disable-next-line no-console
+          console.error("Failed to load roads.json", err);
         }
       });
 
     return () => {
-      isMounted = false;
+      controller.abort();
     };
   }, []);
 

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Card, Dropdown, DropdownProps } from "semantic-ui-react";
+import { Dropdown, DropdownProps } from "semantic-ui-react";
 import { IFavorite, IRoad } from "./types";
 
 interface IDropdownOption {
@@ -15,8 +15,9 @@ type HeaderProps = {
 };
 
 // Reserve the same vertical space whether the dropdown is loading or ready,
-// to avoid a layout shift when the roads list arrives.
-const RESERVED_HEIGHT = "62px";
+// to avoid a layout shift when the roads list arrives. Matches the natural
+// height of a `selection` Dropdown so the loaded state sits flush.
+const RESERVED_HEIGHT = "38px";
 
 const Header = (props: HeaderProps) => {
   const [dropdownOptions, setDropdownOptions] = useState<IDropdownOption[]>([]);
@@ -53,21 +54,20 @@ const Header = (props: HeaderProps) => {
   }
 
   return (
-    <Card fluid style={{ minHeight: RESERVED_HEIGHT }}>
-      <Dropdown
-        placeholder="Velg tunnel(er)"
-        onChange={addFavorite}
-        fluid
-        search
-        selection
-        multiple
-        closeOnChange
-        defaultOpen={props.favorites.length === 0}
-        value={props.favorites}
-        options={dropdownOptions}
-      />
-    </Card>
+    <Dropdown
+      placeholder="Velg tunnel(er)"
+      onChange={addFavorite}
+      fluid
+      search
+      selection
+      multiple
+      closeOnChange
+      defaultOpen={props.favorites.length === 0}
+      value={props.favorites}
+      options={dropdownOptions}
+    />
   );
 };
 
 export default Header;
+

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Card, Dropdown, DropdownProps } from "semantic-ui-react";
 import { IFavorite, IRoad } from "./types";
 
@@ -15,6 +14,10 @@ type HeaderProps = {
   setFavorites: (f: IFavorite[]) => void;
 };
 
+// Reserve the same vertical space whether the dropdown is loading or ready,
+// to avoid a layout shift when the roads list arrives.
+const RESERVED_HEIGHT = "62px";
+
 const Header = (props: HeaderProps) => {
   const [dropdownOptions, setDropdownOptions] = useState<IDropdownOption[]>([]);
 
@@ -24,19 +27,6 @@ const Header = (props: HeaderProps) => {
         key: r.urlFriendly,
         value: r.urlFriendly,
         text: r.roadName,
-        content: (
-          <>
-            <a
-              onClick={(e) => {
-                e.preventDefault();
-                return false;
-              }}
-              href={"https://stengttunnel.no/" + r.urlFriendly}
-            >
-              {r.roadName}
-            </a>
-          </>
-        ),
       }))
     );
   }, [props.roads]);
@@ -51,29 +41,32 @@ const Header = (props: HeaderProps) => {
     }, 100);
   };
 
+  // While roads are loading, render an empty placeholder of the same height
+  // so the layout below does not shift when the dropdown appears.
   if (dropdownOptions.length < 1) {
-    return <></>;
+    return (
+      <div
+        style={{ minHeight: RESERVED_HEIGHT }}
+        aria-hidden="true"
+      />
+    );
   }
 
   return (
-    <>
-      <Card fluid>
-        <Dropdown
-          placeholder="Velg tunnel(er)"
-          onChange={addFavorite}
-          fluid
-          search
-          selection
-          multiple
-          closeOnChange
-          defaultOpen={props.favorites.length === 0}
-          value={props.favorites}
-          disabled={!Boolean(dropdownOptions.length)}
-          loading={!Boolean(dropdownOptions.length)}
-          options={dropdownOptions}
-        />
-      </Card>
-    </>
+    <Card fluid style={{ minHeight: RESERVED_HEIGHT }}>
+      <Dropdown
+        placeholder="Velg tunnel(er)"
+        onChange={addFavorite}
+        fluid
+        search
+        selection
+        multiple
+        closeOnChange
+        defaultOpen={props.favorites.length === 0}
+        value={props.favorites}
+        options={dropdownOptions}
+      />
+    </Card>
   );
 };
 

--- a/src/Road.tsx
+++ b/src/Road.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useMemo } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { IRoad, IRoadStatus, ISource } from "./types";
 import { Card, Feed, Popup, Item, Button } from "semantic-ui-react";
 import { ReactComponent as StatusSvg } from "./status.svg";
@@ -7,66 +7,88 @@ type RoadProps = {
   road: IRoad;
 };
 
-const Road: FC<any> = (props: RoadProps) => {
+// Reserve roughly the height of a typical loaded road card (status header +
+// one or two messages) to keep CLS low while the per-road status is fetched.
+const ROAD_MIN_HEIGHT = "220px";
+
+const Road: FC<RoadProps> = (props: RoadProps) => {
   const [road, setRoad] = useState<IRoadStatus>();
   const [shouldUpdate, setShouldUpdate] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<boolean>(false);
   const { roadName } = props.road;
 
-  useMemo(() => {
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState === "visible") {
-        setShouldUpdate(true);
-      } else {
-        setShouldUpdate(false);
-      }
-    });
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      setShouldUpdate(document.visibilityState === "visible");
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
   }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     setLoading(true);
-    fetch(props.road.url)
-      .then((r) => r.json())
+    setError(false);
+
+    fetch(props.road.url, { signal: controller.signal })
       .then((r) => {
-        return {
-          ...r,
-          ...props.road,
-        };
+        if (!r.ok) {
+          throw new Error(`HTTP ${r.status}`);
+        }
+        return r.json();
       })
-      .then(setRoad)
-      .then(() => setLoading(false));
+      .then((r) => {
+        setRoad({ ...r, ...props.road });
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === "AbortError") {
+          return;
+        }
+        setError(true);
+        setLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
   }, [props.road, shouldUpdate]);
 
-  if (loading) {
+  if (loading || error) {
     return (
-      <Card fluid>
+      <Card fluid style={{ minHeight: ROAD_MIN_HEIGHT }}>
         <Card.Content>
           <Item.Group>
-            <Popup
-              on={["click"]}
-              trigger={
-                <Button
-                  onClick={() => {}}
-                  style={{ position: "absolute", right: "10px" }}
-                  icon="external share"
-                  alt="Del link til stengttunnel.no"
-                  circular
-                  basic
-                ></Button>
-              }
-              content="Kopiert linken"
-              inverted
-            />
             <Item floated="left" style={{ margin: 0 }}>
               <Item.Image style={{ width: "auto" }} size="tiny">
                 <StatusSvg
                   role="img"
-                  aria-label="Trafikklys som viser gult lys"
+                  aria-label={
+                    error
+                      ? "Trafikklys som viser gult lys (status utilgjengelig)"
+                      : "Trafikklys som viser gult lys"
+                  }
                   className="yellow"
                 />
               </Item.Image>
               <Item.Content verticalAlign="middle">
-                <Item.Header as="h2" aria-label={`Vennligst vent. Laster status for ${roadName}`}>Tunnelen er ...</Item.Header>
+                <Item.Header
+                  as="h2"
+                  aria-label={
+                    error
+                      ? `Klarte ikke å hente status for ${roadName}`
+                      : `Vennligst vent. Laster status for ${roadName}`
+                  }
+                >
+                  {error
+                    ? `${roadName}: Status utilgjengelig`
+                    : "Tunnelen er ..."}
+                </Item.Header>
               </Item.Content>
             </Item>
           </Item.Group>
@@ -136,7 +158,7 @@ const Road: FC<any> = (props: RoadProps) => {
   });
 
   const share = async () => {
-    let shareNavigator = window.navigator as any;
+    const shareNavigator = window.navigator as any;
     const host = new URL(window.location.href);
     const url = `${host.protocol}//${host.host}/${props.road.urlFriendly}`;
 
@@ -159,7 +181,7 @@ const Road: FC<any> = (props: RoadProps) => {
   };
 
   return (
-    <Card fluid data-testid="road">
+    <Card fluid data-testid="road" style={{ minHeight: ROAD_MIN_HEIGHT }}>
       <Card.Content>
         <Item.Group>
           <Popup
@@ -186,7 +208,7 @@ const Road: FC<any> = (props: RoadProps) => {
               />
             </Item.Image>
             <Item.Content verticalAlign="middle">
-              <Item.Header data-testid="status" as="h2" tabIndex="1">
+              <Item.Header data-testid="status" as="h2">
                 {statusMessage.replace(/^Tunnelen/, roadName)}
               </Item.Header>
             </Item.Content>

--- a/src/Roads.tsx
+++ b/src/Roads.tsx
@@ -25,7 +25,7 @@ const RoadAndAd = React.forwardRef<HTMLDivElement, RoadAndAdProps>(
     return (
       <div ref={ref}>
         <Road road={r} />
-        {!props.adsDisabled && <Divider />}
+        <Divider hidden={props.adsDisabled} />
         {!props.adsDisabled && (props.showAd ? <Ad /> : <Annonse />)}
       </div>
     );

--- a/src/Roads.tsx
+++ b/src/Roads.tsx
@@ -16,6 +16,7 @@ type RoadsProps = {
 type RoadAndAdProps = {
   road: IRoad;
   showAd: boolean;
+  adsDisabled: boolean;
 };
 
 const RoadAndAd = React.forwardRef<HTMLDivElement, RoadAndAdProps>(
@@ -24,8 +25,8 @@ const RoadAndAd = React.forwardRef<HTMLDivElement, RoadAndAdProps>(
     return (
       <div ref={ref}>
         <Road road={r} />
-        <Divider />
-        {props.showAd ? <Ad /> : <Annonse />}
+        {!props.adsDisabled && <Divider />}
+        {!props.adsDisabled && (props.showAd ? <Ad /> : <Annonse />)}
       </div>
     );
   }
@@ -44,6 +45,10 @@ const Roads = (props: RoadsProps) => {
   const [isMobile, setMobile] = useState<boolean>(false);
   const refsRef = useRef<Array<RefObject<HTMLDivElement>>>([]);
   const activeIndexRef = useRef<number>(0);
+  // Disable ads in environments that set REACT_APP_DISABLE_ADS=true
+  // (e.g. Cloudflare preview deployments) so previewers don't see large
+  // empty ad placeholders.
+  const adsDisabled = process.env.REACT_APP_DISABLE_ADS === "true";
 
   useEffect(() => {
     const onResize = () => setMobile(isMobileViewport());
@@ -107,6 +112,7 @@ const Roads = (props: RoadsProps) => {
           key={r.urlFriendly}
           road={r}
           showAd={adChoices[i]}
+          adsDisabled={adsDisabled}
         />
       ))}
       {isMobile && orderedRoads.length > 1 && (

--- a/src/Roads.tsx
+++ b/src/Roads.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { RefObject } from "react";
 
 import { Divider, Button } from "semantic-ui-react";
@@ -15,83 +15,109 @@ type RoadsProps = {
 
 type RoadAndAdProps = {
   road: IRoad;
+  showAd: boolean;
 };
 
-type RefDataObject = {
-  active: boolean;
-  road: IRoad;
-  ref: RefObject<HTMLDivElement>;
-  key: string;
-};
+const RoadAndAd = React.forwardRef<HTMLDivElement, RoadAndAdProps>(
+  (props, ref) => {
+    const r = props.road;
+    return (
+      <div ref={ref}>
+        <Road road={r} />
+        <Divider />
+        {props.showAd ? <Ad /> : <Annonse />}
+      </div>
+    );
+  }
+);
 
-const RoadAndAd = React.forwardRef((props: RoadAndAdProps, ref: any) => {
-  const r = props.road;
-  const showAd = window.adsbygoogle?.loaded && Math.random() < 0.5;
-  return (
-    <div ref={ref} key={`container-${r.urlFriendly}`}>
-      <Road road={r} />
-      <Divider />
-      {showAd ? <Ad /> : <Annonse />}
-    </div>
-  );
-});
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const isMobileViewport = () =>
+  typeof window !== "undefined" &&
+  (window.innerWidth < 600 || window.innerHeight < 900);
 
 const Roads = (props: RoadsProps) => {
   const [isMobile, setMobile] = useState<boolean>(false);
-  const refs: RefDataObject[] = [];
+  const refsRef = useRef<Array<RefObject<HTMLDivElement>>>([]);
+  const activeIndexRef = useRef<number>(0);
 
   useEffect(() => {
-    setMobile(window.innerWidth < 600 || window.innerHeight < 900);
+    const onResize = () => setMobile(isMobileViewport());
+    onResize();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("orientationchange", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("orientationchange", onResize);
+    };
   }, []);
 
-  const roads = [...props.favorites]
-    .reverse()
-    .map((f) => props.roads.find((r) => r.urlFriendly === f))
-    .filter(Boolean)
-    .map((value, i) => {
-      const r = value as IRoad;
-      const ref = React.createRef<HTMLDivElement>();
-      refs.push({
-        active: i === 0 ? true : false,
-        ref,
-        road: r,
-        key: r.urlFriendly,
-      });
-      return <RoadAndAd ref={ref} key={r.urlFriendly} road={r} />;
+  const orderedRoads = useMemo(() => {
+    return [...props.favorites]
+      .reverse()
+      .map((f) => props.roads.find((r) => r.urlFriendly === f))
+      .filter(Boolean) as IRoad[];
+  }, [props.favorites, props.roads]);
+
+  // Decide showAd once per road in the list, deterministically per render of
+  // the list (still random, but doesn't flip if a child re-renders).
+  const adChoices = useMemo(
+    () =>
+      orderedRoads.map(
+        () => Boolean(window.adsbygoogle?.loaded) && Math.random() < 0.5
+      ),
+    [orderedRoads]
+  );
+
+  // Keep the refs array in sync with the rendered list (no mutation during render).
+  if (refsRef.current.length !== orderedRoads.length) {
+    refsRef.current = orderedRoads.map(
+      (_, i) => refsRef.current[i] ?? React.createRef<HTMLDivElement>()
+    );
+    activeIndexRef.current = 0;
+  }
+
+  const scrollToNextRoad = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const button = (event.target as HTMLElement).closest("button");
+    const refs = refsRef.current;
+    if (refs.length === 0) return;
+
+    const nextIndex = (activeIndexRef.current + 1) % refs.length;
+    activeIndexRef.current = nextIndex;
+
+    refs[nextIndex].current?.scrollIntoView({
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
     });
 
-  const scrollToNextRoad = (event: any, data: any) => {
-    const button = event.target.closest("button");
-    let activeRoadIndex = refs.findIndex((r) => r.active === true);
-    refs[activeRoadIndex].active = false;
-
-    const nextRoadIndex = ++activeRoadIndex % refs.length;
-    const nextRoad = refs[nextRoadIndex];
-
-    nextRoad.active = true;
-    refs[nextRoadIndex] = nextRoad;
-    nextRoad.ref.current?.scrollIntoView({
-      behavior: "smooth",
-    });
-
-    if (nextRoadIndex === refs.length - 1) {
-      button.style.transform = "rotate(-180deg)";
-    } else {
-      button.style.transform = "rotate(0)";
+    if (button) {
+      button.style.transform =
+        nextIndex === refs.length - 1 ? "rotate(-180deg)" : "rotate(0)";
     }
   };
 
   return (
     <>
-      {roads}
-      {isMobile && (
+      {orderedRoads.map((r, i) => (
+        <RoadAndAd
+          ref={refsRef.current[i]}
+          key={r.urlFriendly}
+          road={r}
+          showAd={adChoices[i]}
+        />
+      ))}
+      {isMobile && orderedRoads.length > 1 && (
         <Button
           size="massive"
           color="red"
           circular
           active={false}
           icon={`arrow down`}
-          onClick={(event, data) => scrollToNextRoad(event, data)}
+          aria-label="Bla til neste tunnel"
+          onClick={scrollToNextRoad}
           style={{
             zIndex: 10000,
             position: "fixed",

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,9 @@ input[type=text] {
     transition-duration: 0.4s;
     transform: rotate(0deg);
 }
+
+@media (prefers-reduced-motion: reduce) {
+    .ui.red.button {
+        transition: none;
+    }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,15 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "fomantic-ui-css/semantic.min.css";
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
-);
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-// reportWebVitals(console.log);
+const container = document.getElementById("root");
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- Bytter ut iframe mot `annon-se.stengttunnel.no` med en selvstendig, statisk reklame for [båtførerquizen.no](https://xn--btfrerquizen-tcb2y.no/).
- Beholder komponentnavnet `Annonse`, så `Roads.tsx` (`<Annonse />`) trenger ingen endring.
- Markup/styling portet 1:1 fra `web/annonse-stengttunnel.html` i båtførerquizen-repoet, men med `bfq-ad`-prefiks for å unngå CSS-kollisjoner.

## Detaljer
- Lenker til `https://xn--btfrerquizen-tcb2y.no/` med `utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse`.
- Rullerende verdiforslag (139 spørsmål, 599,-, ★★★★★ osv.) med 3 sek intervall.
- Respekterer `prefers-reduced-motion`.
- Mobil-layout (≤480px) som faller tilbake til full-bredde CTA.

## Effekter
- Fjerner ekstern iframe-avhengighet → mindre CLS, raskere render, ingen `postMessage`-håndtering.
- Ingen flere kall til `annon-se.stengttunnel.no`.