### PR TITLE
feat(Annonse): rotate between Båtførerquizen and 1 G

### DIFF
--- a/src/Annonse.css
+++ b/src/Annonse.css
@@ -3,12 +3,15 @@
   width: 100%;
   max-width: 640px;
   margin: 0 auto;
-  background: linear-gradient(135deg, #06111e 0%, #0b2545 55%, #13315c 100%);
+  background: var(
+    --bfq-gradient,
+    linear-gradient(135deg, #06111e 0%, #0b2545 55%, #13315c 100%)
+  );
   color: #fff;
   border-radius: 14px;
   overflow: hidden;
   text-decoration: none;
-  box-shadow: 0 6px 20px rgba(11, 37, 69, 0.18);
+  box-shadow: 0 6px 20px var(--bfq-shadow, rgba(11, 37, 69, 0.18));
   position: relative;
   transition: transform 0.12s ease, box-shadow 0.2s ease;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -18,7 +21,7 @@
 }
 .bfq-ad:hover {
   transform: translateY(-2px);
-  box-shadow: 0 12px 28px rgba(11, 37, 69, 0.28);
+  box-shadow: 0 12px 28px var(--bfq-shadow, rgba(11, 37, 69, 0.28));
 }
 
 .bfq-ad::after {
@@ -52,8 +55,8 @@
   width: 56px;
   height: 56px;
   border-radius: 12px;
-  background: rgba(142, 202, 230, 0.15);
-  border: 1px solid rgba(142, 202, 230, 0.3);
+  background: var(--bfq-icon-bg, rgba(142, 202, 230, 0.15));
+  border: 1px solid var(--bfq-icon-border, rgba(142, 202, 230, 0.3));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -70,7 +73,7 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #8ecae6;
+  color: var(--bfq-accent, #8ecae6);
   font-weight: 700;
   margin-bottom: 4px;
 }
@@ -109,20 +112,20 @@
   font-weight: 700;
 }
 .bfq-ad-rotator .accent {
-  color: #8ecae6;
+  color: var(--bfq-accent, #8ecae6);
   font-weight: 700;
 }
 
 .bfq-ad-cta {
   flex-shrink: 0;
-  background: #1d6fb8;
+  background: var(--bfq-cta-bg, #1d6fb8);
   color: #fff;
   padding: 10px 16px;
   border-radius: 10px;
   font-weight: 600;
   font-size: 14px;
   white-space: nowrap;
-  box-shadow: 0 4px 10px rgba(29, 111, 184, 0.4);
+  box-shadow: 0 4px 10px var(--bfq-cta-shadow, rgba(29, 111, 184, 0.4));
 }
 
 @media (max-width: 480px) {

--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -3,6 +3,10 @@ import "./Annonse.css";
 
 type Campaign = {
   id: string;
+  // Relative share of impressions. Values are summed across all campaigns
+  // and used as a weighted distribution; they do not need to add up to 1
+  // or 100. Set to 0 to disable a campaign without removing it.
+  weight: number;
   href: string;
   ariaLabel: string;
   eyebrow: string;
@@ -25,6 +29,7 @@ type Campaign = {
 
 const BATFORERQUIZEN: Campaign = {
   id: "batforerquizen",
+  weight: 80,
   href: "https://xn--btfrerquizen-tcb2y.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse",
   ariaLabel: "Båtførerquizen – øv til båtførerprøven på nett",
   eyebrow: "Båtførerquizen.no",
@@ -65,6 +70,7 @@ const BATFORERQUIZEN: Campaign = {
 
 const REGNSKAP_1G: Campaign = {
   id: "1g",
+  weight: 20,
   href: "https://1-g.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse",
   ariaLabel: "1 G – norsk regnskap for 29 kroner i måneden",
   eyebrow: "1-g.no",
@@ -110,14 +116,26 @@ const CAMPAIGNS: Campaign[] = [BATFORERQUIZEN, REGNSKAP_1G];
 
 const ROTATE_INTERVAL_MS = 3000;
 
+// Pick a campaign using each campaign's `weight` as relative share. Weights
+// are summed, so e.g. weights of 80 and 20 give a 80%/20% split, but 4 and 1
+// would yield the same distribution.
+const pickWeightedCampaign = (campaigns: Campaign[]): Campaign => {
+  const eligible = campaigns.filter((c) => c.weight > 0);
+  if (eligible.length === 0) return campaigns[0];
+  const total = eligible.reduce((sum, c) => sum + c.weight, 0);
+  let roll = Math.random() * total;
+  for (const c of eligible) {
+    roll -= c.weight;
+    if (roll < 0) return c;
+  }
+  return eligible[eligible.length - 1];
+};
+
 const Annonse = () => {
   // Pick one campaign per mount so the user sees the same ad while the page
   // is open, but different visits / different RoadAndAd instances rotate
-  // between campaigns.
-  const campaign = useMemo(
-    () => CAMPAIGNS[Math.floor(Math.random() * CAMPAIGNS.length)],
-    []
-  );
+  // between campaigns according to the configured weights.
+  const campaign = useMemo(() => pickWeightedCampaign(CAMPAIGNS), []);
   const [current, setCurrent] = useState(0);
 
   useEffect(() => {

--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -1,60 +1,163 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import "./Annonse.css";
 
-const SLIDES: React.ReactNode[] = [
-  <>
-    <span className="accent">139</span> oppdaterte spørsmål i{" "}
-    <strong>25 kategorier</strong>
-  </>,
-  <>
-    <strong>599,-</strong> for 3 måneders full tilgang
-  </>,
-  <>
-    Umiddelbar <strong>forklaring</strong> og kildehenvisning
-  </>,
-  <>
-    Øv på <strong>mobil, nettbrett og PC</strong> – ingen app
-  </>,
-  <>
-    Ingen automatisk fornyelse – <strong>engangskjøp</strong>
-  </>,
-  <>
-    <span className="accent">★★★★★</span> 4,9 av 5 i kundevurdering
-  </>,
-];
+type Campaign = {
+  id: string;
+  href: string;
+  ariaLabel: string;
+  eyebrow: string;
+  title: string;
+  icon: string;
+  cta: string;
+  slides: React.ReactNode[];
+  // CSS variables applied to the root anchor; see Annonse.css for the
+  // variable names. Lets each campaign theme the same banner shell.
+  theme: {
+    gradient: string;
+    iconBg: string;
+    iconBorder: string;
+    accent: string;
+    ctaBg: string;
+    ctaShadow: string;
+    shadow: string;
+  };
+};
+
+const BATFORERQUIZEN: Campaign = {
+  id: "batforerquizen",
+  href: "https://xn--btfrerquizen-tcb2y.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse",
+  ariaLabel: "Båtførerquizen – øv til båtførerprøven på nett",
+  eyebrow: "Båtførerquizen.no",
+  title: "Bestå båtførerprøven – med selvtillit",
+  icon: "⚓",
+  cta: "Start quiz →",
+  slides: [
+    <>
+      <span className="accent">139</span> oppdaterte spørsmål i{" "}
+      <strong>25 kategorier</strong>
+    </>,
+    <>
+      <strong>599,-</strong> for 3 måneders full tilgang
+    </>,
+    <>
+      Umiddelbar <strong>forklaring</strong> og kildehenvisning
+    </>,
+    <>
+      Øv på <strong>mobil, nettbrett og PC</strong> – ingen app
+    </>,
+    <>
+      Ingen automatisk fornyelse – <strong>engangskjøp</strong>
+    </>,
+    <>
+      <span className="accent">★★★★★</span> 4,9 av 5 i kundevurdering
+    </>,
+  ],
+  theme: {
+    gradient: "linear-gradient(135deg, #06111e 0%, #0b2545 55%, #13315c 100%)",
+    iconBg: "rgba(142, 202, 230, 0.15)",
+    iconBorder: "rgba(142, 202, 230, 0.3)",
+    accent: "#8ecae6",
+    ctaBg: "#1d6fb8",
+    ctaShadow: "rgba(29, 111, 184, 0.4)",
+    shadow: "rgba(11, 37, 69, 0.18)",
+  },
+};
+
+const REGNSKAP_1G: Campaign = {
+  id: "1g",
+  href: "https://1-g.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse",
+  ariaLabel: "1 G – norsk regnskap for 29 kroner i måneden",
+  eyebrow: "1-g.no",
+  title: "Norsk regnskap for 29,-/mnd",
+  icon: "🧾",
+  cta: "Kom i gang →",
+  slides: [
+    <>
+      Regnskap for <strong>29,-/mnd</strong>
+    </>,
+    <>
+      <span className="accent">🇳🇴</span> Bygget for{" "}
+      <strong>norske regler</strong>
+    </>,
+    <>
+      MVA-melding rett til <strong>Skatteetaten</strong>
+    </>,
+    <>
+      Ingen oppstartskostnad – <strong>si opp når du vil</strong>
+    </>,
+    <>
+      Faktura, MVA og bokføring – <strong>alt inkludert</strong>
+    </>,
+    <>
+      Brøkdel av <strong>Fiken/Tripletex</strong>-prisen
+    </>,
+    <>
+      Klar på <span className="accent">2 minutter</span>
+    </>,
+  ],
+  theme: {
+    gradient: "linear-gradient(135deg, #0b1220 0%, #111827 55%, #1e293b 100%)",
+    iconBg: "rgba(96, 165, 250, 0.18)",
+    iconBorder: "rgba(96, 165, 250, 0.35)",
+    accent: "#60a5fa",
+    ctaBg: "#2563eb",
+    ctaShadow: "rgba(37, 99, 235, 0.4)",
+    shadow: "rgba(17, 24, 39, 0.22)",
+  },
+};
+
+const CAMPAIGNS: Campaign[] = [BATFORERQUIZEN, REGNSKAP_1G];
 
 const ROTATE_INTERVAL_MS = 3000;
 
 const Annonse = () => {
+  // Pick one campaign per mount so the user sees the same ad while the page
+  // is open, but different visits / different RoadAndAd instances rotate
+  // between campaigns.
+  const campaign = useMemo(
+    () => CAMPAIGNS[Math.floor(Math.random() * CAMPAIGNS.length)],
+    []
+  );
   const [current, setCurrent] = useState(0);
 
   useEffect(() => {
-    if (SLIDES.length <= 1) return;
+    if (campaign.slides.length <= 1) return;
     const id = window.setInterval(() => {
-      setCurrent((c) => (c + 1) % SLIDES.length);
+      setCurrent((c) => (c + 1) % campaign.slides.length);
     }, ROTATE_INTERVAL_MS);
     return () => window.clearInterval(id);
-  }, []);
+  }, [campaign]);
+
+  // Map theme values to CSS custom properties consumed by Annonse.css.
+  const themeStyle = {
+    "--bfq-gradient": campaign.theme.gradient,
+    "--bfq-icon-bg": campaign.theme.iconBg,
+    "--bfq-icon-border": campaign.theme.iconBorder,
+    "--bfq-accent": campaign.theme.accent,
+    "--bfq-cta-bg": campaign.theme.ctaBg,
+    "--bfq-cta-shadow": campaign.theme.ctaShadow,
+    "--bfq-shadow": campaign.theme.shadow,
+  } as React.CSSProperties;
 
   return (
     <a
       className="bfq-ad"
-      href="https://xn--btfrerquizen-tcb2y.no/?utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse"
+      href={campaign.href}
       target="_blank"
-      rel="noopener noreferrer"
-      aria-label="Båtførerquizen – øv til båtførerprøven på nett"
+      rel="noopener noreferrer sponsored"
+      aria-label={campaign.ariaLabel}
+      data-campaign={campaign.id}
+      style={themeStyle}
     >
       <div className="bfq-ad-inner">
         <div className="bfq-ad-icon" aria-hidden="true">
-          ⚓
+          {campaign.icon}
         </div>
         <div className="bfq-ad-body">
-          <div className="bfq-ad-eyebrow">Båtførerquizen.no</div>
-          <div className="bfq-ad-title">
-            Bestå båtførerprøven – med selvtillit
-          </div>
+          <div className="bfq-ad-eyebrow">{campaign.eyebrow}</div>
+          <div className="bfq-ad-title">{campaign.title}</div>
           <div className="bfq-ad-rotator" aria-live="polite">
-            {SLIDES.map((slide, i) => (
+            {campaign.slides.map((slide, i) => (
               <div
                 key={i}
                 className={`bfq-ad-slide${
@@ -66,7 +169,7 @@ const Annonse = () => {
             ))}
           </div>
         </div>
-        <div className="bfq-ad-cta">Start quiz →</div>
+        <div className="bfq-ad-cta">{campaign.cta}</div>
       </div>
     </a>
   );


### PR DESCRIPTION
## Summary

Utvider `<Annonse />` til å rotere mellom to kampanjer i stedet for bare én. Hver gang komponenten monteres, velges en kampanje tilfeldig — så samme bruker ser samme annonse mens siden er åpen, men forskjellige besøk og forskjellige `RoadAndAd`-instanser kan vise forskjellige kampanjer.

## Kampanjer

| | Båtførerquizen | 1 G — Regnskap |
|---|---|---|
| URL | xn--btfrerquizen-tcb2y.no | 1-g.no |
| Eyebrow | Båtførerquizen.no | 1-g.no |
| Title | Bestå båtførerprøven – med selvtillit | Norsk regnskap for 29,-/mnd |
| Icon | ⚓ | 🧾 |
| CTA | Start quiz → | Kom i gang → |
| Tema | Navy / cyan | Slate / blå |

Alle lenker har `utm_source=stengttunnel&utm_medium=banner&utm_campaign=annonse` så trafikken er sporbar.

## Implementasjon

- `Campaign`-type i `Annonse.tsx` beskriver innhold + tema.
- Tema er CSS custom properties (`--bfq-gradient`, `--bfq-accent`, `--bfq-cta-bg`, …) satt inline på rotelementet; `Annonse.css` leser variablene med fallback til original Båtførerquizen-paletten.
- `useMemo` velger kampanje ved mount, så samme banner ikke bytter identitet midt i en visning.
- `data-campaign`-attributt på rot for ev. analytics-bruk senere.

## Slides for 1 G

- Regnskap for **29,-/mnd**
- 🇳🇴 Bygget for **norske regler**
- MVA-melding rett til **Skatteetaten**
- Ingen oppstartskostnad – **si opp når du vil**
- Faktura, MVA og bokføring – **alt inkludert**
- Brøkdel av **Fiken/Tripletex**-prisen
- Klar på **2 minutter**

## Tester

`npm test` passerer (2/2). `npm run build` + purgecss kjører rent.