### PR TITLE
style(Annonse): distinct burgundy/gold theme for 1 G

### DIFF
--- a/src/Annonse.tsx
+++ b/src/Annonse.tsx
@@ -102,13 +102,13 @@ const REGNSKAP_1G: Campaign = {
     </>,
   ],
   theme: {
-    gradient: "linear-gradient(135deg, #0b1220 0%, #111827 55%, #1e293b 100%)",
-    iconBg: "rgba(96, 165, 250, 0.18)",
-    iconBorder: "rgba(96, 165, 250, 0.35)",
-    accent: "#60a5fa",
-    ctaBg: "#2563eb",
-    ctaShadow: "rgba(37, 99, 235, 0.4)",
-    shadow: "rgba(17, 24, 39, 0.22)",
+    gradient: "linear-gradient(135deg, #1a0b1f 0%, #3d1a3a 55%, #5b2a4a 100%)",
+    iconBg: "rgba(244, 196, 96, 0.18)",
+    iconBorder: "rgba(244, 196, 96, 0.4)",
+    accent: "#f4c460",
+    ctaBg: "#c9943a",
+    ctaShadow: "rgba(201, 148, 58, 0.45)",
+    shadow: "rgba(61, 26, 58, 0.28)",
   },
 };
 


### PR DESCRIPTION
1 G-annonsen brukte mørk slate/blå som lå for tett opp mot Båtførerquizens navy/cyan-palett — de to bannerne så like ut ved første øyekast. Bytter 1 G til dyp burgunder/plum-gradient (`#1a0b1f → #3d1a3a → #5b2a4a`) med gull-accent (`#f4c460`) og varmere CTA (`#c9943a`). Tydelig skille fra Båtførerquizen, beholder samme banner-struktur og kontrast.